### PR TITLE
Fix build by excluding fluent-ffmpeg from bundle

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,15 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next';
+import webpack from 'webpack';
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  webpack: (config, { isServer }) => {
+    if (isServer) {
+      config.externals = Array.isArray(config.externals)
+        ? [...config.externals, 'fluent-ffmpeg']
+        : ['fluent-ffmpeg'];
+    }
+    return config;
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- exclude `fluent-ffmpeg` from server bundling via webpack externals

## Testing
- `npm run build` *(fails: ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6858684e00748322bf45889e2c34b5e8