### PR TITLE
Fix whatsapp status error with turbopack

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,9 @@ import type { NextConfig } from 'next';
 import webpack from 'webpack';
 
 const nextConfig: NextConfig = {
+  experimental: {
+    serverExternalPackages: ['fluent-ffmpeg'],
+  },
   webpack: (config, { isServer }) => {
     if (isServer) {
       config.externals = Array.isArray(config.externals)


### PR DESCRIPTION
## Summary
- externalize `fluent-ffmpeg` for Turbopack builds

## Testing
- `npm run lint` *(fails: many eslint errors)*
- `npm run build` *(fails: compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_68586ca6b0748322a90e04c68bb3301c