### PR TITLE
Fix Next.js config for fluent-ffmpeg

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,9 +2,7 @@ import type { NextConfig } from 'next';
 import webpack from 'webpack';
 
 const nextConfig: NextConfig = {
-  experimental: {
-    serverExternalPackages: ['fluent-ffmpeg'],
-  },
+  serverExternalPackages: ['fluent-ffmpeg'],
   webpack: (config, { isServer }) => {
     if (isServer) {
       config.externals = Array.isArray(config.externals)


### PR DESCRIPTION
## Summary
- move `serverExternalPackages` to correct top-level property in `next.config.ts`

## Testing
- `npm run lint` *(fails: prefer-const, no-explicit-any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68586ecb3e248322a68c25242be3db49