### PR TITLE
Remove webpack configuration to avoid turbopack crash

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,16 +1,8 @@
 import type { NextConfig } from 'next';
-import webpack from 'webpack';
+// Turbopack doesn't support custom webpack configuration.
 
 const nextConfig: NextConfig = {
   serverExternalPackages: ['fluent-ffmpeg'],
-  webpack: (config, { isServer }) => {
-    if (isServer) {
-      config.externals = Array.isArray(config.externals)
-        ? [...config.externals, 'fluent-ffmpeg']
-        : ['fluent-ffmpeg'];
-    }
-    return config;
-  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- cleanup `next.config.ts` and remove legacy webpack config

## Testing
- `npm install --ignore-scripts`
- `npm run lint` *(fails: prefer-const, no-explicit-any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685872ac39408322b3e53d267cb4a893