### PR TITLE
Add authenticateRequest util and secure WhatsApp API

### DIFF
--- a/src/app/api/whatsapp/analytics/route.ts
+++ b/src/app/api/whatsapp/analytics/route.ts
@@ -1,8 +1,16 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { getWhatsAppService } from '@/lib/whatsapp-service';
+import { authenticateRequest } from '@/lib/edge-auth';
 
-export async function GET(request: Request) {
+export async function GET(request: NextRequest) {
   try {
+    const authResult = await authenticateRequest(request);
+    if (!authResult.isAuthenticated) {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
     const { searchParams } = new URL(request.url);
     const clientId = searchParams.get('clientId') || undefined;
     const caseId = searchParams.get('caseId') || undefined;

--- a/src/app/api/whatsapp/disconnect/route.ts
+++ b/src/app/api/whatsapp/disconnect/route.ts
@@ -1,9 +1,17 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { getWhatsAppService } from '@/lib/whatsapp-service';
+import { authenticateRequest } from '@/lib/edge-auth';
 
 // POST handler for disconnecting WhatsApp
-export async function POST() {
+export async function POST(request: NextRequest) {
   try {
+    const authResult = await authenticateRequest(request);
+    if (!authResult.isAuthenticated) {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
     const whatsappService = getWhatsAppService();
     
     // Important fix: Use setTimeout to avoid waiting for complete disconnection

--- a/src/app/api/whatsapp/history/route.ts
+++ b/src/app/api/whatsapp/history/route.ts
@@ -1,8 +1,16 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { getWhatsAppService } from '@/lib/whatsapp-service';
+import { authenticateRequest } from '@/lib/edge-auth';
 
-export async function GET(request: Request) {
+export async function GET(request: NextRequest) {
   try {
+    const authResult = await authenticateRequest(request);
+    if (!authResult.isAuthenticated) {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
     const { searchParams } = new URL(request.url);
     const phoneNumber = searchParams.get('phoneNumber');
     const limit = parseInt(searchParams.get('limit') || '50', 10);

--- a/src/app/api/whatsapp/messages/route.ts
+++ b/src/app/api/whatsapp/messages/route.ts
@@ -1,11 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { PrismaClient } from '@prisma/client';
 import { getWhatsAppService } from '@/lib/whatsapp-service';
+import { authenticateRequest } from '@/lib/edge-auth';
 
 const prisma = new PrismaClient();
 
 export async function GET(request: NextRequest) {
   try {
+    const authResult = await authenticateRequest(request);
+    if (!authResult.isAuthenticated) {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
     const { searchParams } = new URL(request.url);
     const phoneNumber = searchParams.get('phoneNumber');
     const clientId = searchParams.get('clientId');
@@ -64,6 +72,13 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
+    const authResult = await authenticateRequest(request);
+    if (!authResult.isAuthenticated) {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
     const messageData = await request.json();
     await prisma.whatsAppMessage.create({
       data: {

--- a/src/app/api/whatsapp/messages/status/route.ts
+++ b/src/app/api/whatsapp/messages/status/route.ts
@@ -1,10 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { PrismaClient } from '@prisma/client';
+import { authenticateRequest } from '@/lib/edge-auth';
 
 const prisma = new PrismaClient();
 
 export async function PUT(request: NextRequest) {
   try {
+    const authResult = await authenticateRequest(request);
+    if (!authResult.isAuthenticated) {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
     const { messageId, status } = await request.json();
     if (!messageId || !status) {
       return NextResponse.json({ error: 'Message ID and status are required' }, { status: 400 });

--- a/src/app/api/whatsapp/restart/route.ts
+++ b/src/app/api/whatsapp/restart/route.ts
@@ -1,8 +1,16 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { getWhatsAppService } from '@/lib/whatsapp-service';
+import { authenticateRequest } from '@/lib/edge-auth';
 
-export async function POST() {
+export async function POST(request: NextRequest) {
   try {
+    const authResult = await authenticateRequest(request);
+    if (!authResult.isAuthenticated) {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
     const whatsappService = getWhatsAppService();
     await whatsappService.restart();
     return NextResponse.json({ success: true, message: 'WhatsApp service restarted' });

--- a/src/app/api/whatsapp/send/route.ts
+++ b/src/app/api/whatsapp/send/route.ts
@@ -1,8 +1,16 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { getWhatsAppService } from '@/lib/whatsapp-service';
+import { authenticateRequest } from '@/lib/edge-auth';
 
-export async function POST(request: Request) {
+export async function POST(request: NextRequest) {
   try {
+    const authResult = await authenticateRequest(request);
+    if (!authResult.isAuthenticated) {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
     const body = await request.json();
     const { phoneNumber, message, caseId, clientId } = body;
 

--- a/src/app/api/whatsapp/status/route.ts
+++ b/src/app/api/whatsapp/status/route.ts
@@ -1,9 +1,17 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { getWhatsAppService } from '@/lib/whatsapp-service';
+import { authenticateRequest } from '@/lib/edge-auth';
 
 // GET handler for retrieving WhatsApp status
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
+    const authResult = await authenticateRequest(request);
+    if (!authResult.isAuthenticated) {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
     const whatsappService = getWhatsAppService();
     const status = whatsappService.getStatus();
     return NextResponse.json(status);
@@ -17,8 +25,15 @@ export async function GET() {
 }
 
 // POST handler for initializing WhatsApp
-export async function POST() {
+export async function POST(request: NextRequest) {
   try {
+    const authResult = await authenticateRequest(request);
+    if (!authResult.isAuthenticated) {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
     const whatsappService = getWhatsAppService();
     
     // Start initialization process without awaiting - critical fix for protocol error

--- a/src/lib/edge-auth.ts
+++ b/src/lib/edge-auth.ts
@@ -1,6 +1,7 @@
 // lib/edge-auth.ts - Edge Runtime compatible JWT verification
 
 import { JWTPayload } from './auth';
+import type { NextRequest } from 'next/server';
 
 /**
  * Edge Runtime compatible JWT verification using Web Crypto API
@@ -72,4 +73,23 @@ export async function verifyJWTEdge(token: string): Promise<JWTPayload> {
     email: payload.email,
     role: payload.role
   };
+}
+
+/**
+ * Authenticate a request using the auth-token cookie and Edge JWT verification
+ */
+export async function authenticateRequest(
+  request: NextRequest
+): Promise<{ isAuthenticated: boolean; user?: JWTPayload }> {
+  try {
+    const token = request.cookies.get('auth-token')?.value;
+    if (!token) {
+      return { isAuthenticated: false };
+    }
+
+    const decoded = await verifyJWTEdge(token);
+    return { isAuthenticated: true, user: decoded };
+  } catch {
+    return { isAuthenticated: false };
+  }
 }


### PR DESCRIPTION
## Summary
- add `authenticateRequest` helper in `edge-auth`
- require authentication in all WhatsApp API routes

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68589b413f808322855deba5d4fb2aab