### PR TITLE
Fix repeated renders in communication page

### DIFF
--- a/src/app/communication/page.tsx
+++ b/src/app/communication/page.tsx
@@ -342,7 +342,7 @@ export default function CommunicationPage() {
     }
   }, [isAuthenticated, authLoading, router, checkWhatsAppStatus]);
 
-  const loadCommunicationData = async () => {
+  const loadCommunicationData = useCallback(async () => {
     try {
       setIsLoading(true);
 
@@ -467,7 +467,7 @@ export default function CommunicationPage() {
       console.error('Failed to load communication data:', err);
       setIsLoading(false);
     }
-  };
+  }, [selectedTab]);
 
   const refreshMessages = useCallback(async () => {
     if (selectedTab !== 'whatsapp') {


### PR DESCRIPTION
## Summary
- memoize `loadCommunicationData` to stabilize its reference
- call the memoized function from `refreshMessages`

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run build` *(fails: compilation errors due to existing lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_6858a2d2015c8322b948dd206497d165