### PR TITLE
Fix seed script resets

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -6,6 +6,14 @@ const prisma = new PrismaClient();
 async function main() {
   console.log('🌱 Seeding database...');
 
+  // Clear existing data to allow seeding multiple times without errors
+  await prisma.whatsAppMessage.deleteMany();
+  await prisma.task.deleteMany();
+  await prisma.timeEntry.deleteMany();
+  await prisma.case.deleteMany();
+  await prisma.client.deleteMany();
+  await prisma.user.deleteMany();
+
   // Create admin user
   const adminUser = await prisma.user.create({
     data: {


### PR DESCRIPTION
## Summary
- ensure `npm run db:seed` can be executed repeatedly by clearing all tables before inserting demo data

## Testing
- `npm run db:seed` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858a8f4074883228ff0507f64e13fdc