### PR TITLE
Add WhatsApp worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ pnpm dev
 bun dev
 ```
 
+To keep the WhatsApp connection active during development, start the WhatsApp worker in a separate terminal:
+
+```bash
+npm run whatsapp
+```
+
+Run this command alongside `npm run dev` so the WhatsApp client stays connected.
+
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "db:seed": "tsx prisma/seed.ts"
+    "db:seed": "tsx prisma/seed.ts",
+    "whatsapp": "tsx scripts/whatsapp-worker.ts"
   },
   "dependencies": {
     "@prisma/client": "^6.10.1",

--- a/scripts/whatsapp-worker.ts
+++ b/scripts/whatsapp-worker.ts
@@ -1,0 +1,23 @@
+import { getWhatsAppService } from '../src/lib/whatsapp-service';
+
+async function main() {
+  const service = getWhatsAppService();
+  await service.initialize();
+  console.log('WhatsApp worker started');
+}
+
+main().catch((err) => {
+  console.error('Failed to start WhatsApp worker:', err);
+  process.exit(1);
+});
+
+// Keep the process alive and handle shutdown signals
+const keepAlive = setInterval(() => {}, 1000);
+
+const shutdown = () => {
+  clearInterval(keepAlive);
+  process.exit(0);
+};
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);


### PR DESCRIPTION
## Summary
- add WhatsApp worker script
- register npm script to run worker
- document the worker in the README

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858af54a0f483229affa5ea4a1739da