### PR TITLE
Fix whatsapp send error body scope

### DIFF
--- a/src/app/api/whatsapp/send/route.ts
+++ b/src/app/api/whatsapp/send/route.ts
@@ -3,6 +3,12 @@ import { getWhatsAppService } from '@/lib/whatsapp-service';
 import { authenticateRequest } from '@/lib/edge-auth';
 
 export async function POST(request: NextRequest) {
+  let body: {
+    phoneNumber?: string;
+    message?: string;
+    caseId?: string;
+    clientId?: string;
+  } | undefined;
   try {
     const authResult = await authenticateRequest(request);
     if (!authResult.isAuthenticated) {
@@ -11,7 +17,7 @@ export async function POST(request: NextRequest) {
         { status: 401 }
       );
     }
-    const body = await request.json();
+    body = await request.json();
     const { phoneNumber, message, caseId, clientId } = body;
 
     if (!phoneNumber || !message) {
@@ -30,7 +36,9 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(result);
   } catch (error) {
     console.error('WhatsApp send error:', error);
-    const fallbackUrl = `https://wa.me/${body?.phoneNumber?.replace(/\D/g, '')}?text=${encodeURIComponent(body?.message || '')}`;
+    const fallbackUrl = body?.phoneNumber
+      ? `https://wa.me/${body.phoneNumber.replace(/\D/g, '')}?text=${encodeURIComponent(body.message || '')}`
+      : undefined;
     
     return NextResponse.json(
       { 


### PR DESCRIPTION
## Summary
- ensure body is accessible in WhatsApp send route
- compute fallback URL only when body is available

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6858c04b08088322ab89b9602bcd0ec5