### PR TITLE
Use shared Prisma instance in WhatsApp routes

### DIFF
--- a/src/app/api/whatsapp/client-update/route.ts
+++ b/src/app/api/whatsapp/client-update/route.ts
@@ -2,10 +2,8 @@
 // src/app/api/whatsapp/client-update/route.ts
 
 import { NextRequest, NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
 import { authenticateRequest } from '@/lib/edge-auth';
-
-const prisma = new PrismaClient();
+import { prisma } from '@/lib/prisma';
 
 export async function POST(request: NextRequest) {
   try {

--- a/src/app/api/whatsapp/clients/[phoneNumber]/route.ts
+++ b/src/app/api/whatsapp/clients/[phoneNumber]/route.ts
@@ -2,10 +2,8 @@
 // src/app/api/whatsapp/clients/[phoneNumber]/route.ts
 
 import { NextRequest, NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
 import { authenticateRequest } from '@/lib/edge-auth';
-
-const prisma = new PrismaClient();
+import { prisma } from '@/lib/prisma';
 
 export async function GET(
   request: NextRequest,

--- a/src/app/api/whatsapp/clients/route.ts
+++ b/src/app/api/whatsapp/clients/route.ts
@@ -1,8 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
 import { authenticateRequest } from '@/lib/edge-auth';
-
-const prisma = new PrismaClient();
+import { prisma } from '@/lib/prisma';
 
 export async function GET(request: NextRequest) {
   try {

--- a/src/app/api/whatsapp/messages/route.ts
+++ b/src/app/api/whatsapp/messages/route.ts
@@ -1,9 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
 import { getWhatsAppService } from '@/lib/whatsapp-service';
 import { authenticateRequest } from '@/lib/edge-auth';
-
-const prisma = new PrismaClient();
+import { prisma } from '@/lib/prisma';
 
 export async function GET(request: NextRequest) {
   try {

--- a/src/app/api/whatsapp/messages/status/route.ts
+++ b/src/app/api/whatsapp/messages/status/route.ts
@@ -1,8 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { PrismaClient } from '@prisma/client';
 import { authenticateRequest } from '@/lib/edge-auth';
-
-const prisma = new PrismaClient();
+import { prisma } from '@/lib/prisma';
 
 export async function PUT(request: NextRequest) {
   try {


### PR DESCRIPTION
## Summary
- reuse the Prisma client instead of creating a new instance in WhatsApp API routes

## Testing
- `npm run lint` *(fails: prefer-const, unused vars, etc.)*
- `npx tsc --noEmit` *(fails: TS errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6858c20accb48322b2332be53567cf70