### PR TITLE
Add environment example and setup docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Example environment variables for Legal Case Pro
+
+# Database Configuration
+DATABASE_URL=postgresql://username:password@localhost:5432/legal_case_pro
+
+# Authentication
+JWT_SECRET=your_jwt_secret_key
+JWT_EXPIRY=24h
+
+# API Configuration
+NEXT_PUBLIC_API_URL=http://localhost:3000
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -2,25 +2,33 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
-First, run the development server:
+Before running the application you need to set up your environment and database.
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
-```
+1. **Create your local environment file**
 
-To keep the WhatsApp connection active during development, start the WhatsApp worker in a separate terminal:
+   ```bash
+   cp .env.example .env.local
+   ```
 
-```bash
-npm run whatsapp
-```
+2. **Run Prisma migrations**
 
-Run this command alongside `npm run dev` so the WhatsApp client stays connected.
+   ```bash
+   npx prisma migrate dev
+   ```
+
+3. **Start the development server**
+
+   ```bash
+   npm run dev
+   ```
+
+4. **Start the WhatsApp worker in another terminal**
+
+   ```bash
+   npm run whatsapp
+   ```
+
+Run the worker alongside `npm run dev` so the WhatsApp client stays connected.
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 


### PR DESCRIPTION
## Summary
- provide `.env.example` with sample variables
- allow `.env.example` in Git
- document setup steps for env file, migrations, and running both dev and WhatsApp worker

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858c2f20b548322bed0672588c1a3cd